### PR TITLE
Remove windows api code pack nuget

### DIFF
--- a/ConsoleApp/runtest.ps1
+++ b/ConsoleApp/runtest.ps1
@@ -30,9 +30,9 @@ $lines1
 Write-Host
 Write-Host "Starting Explorer #1"
 $dir = Resolve-Path $binPath
-Write-Host "/E,`"$dir`""
+Write-Host "/E, `"$dir`""
 $exps = Get-Process -Name '*explorer*' | Where-Object { $_.MainWindowHandle -gt 0 }
-explorer.exe "/E,`"$dir`""
+explorer.exe "/E," "$dir"
 for ($i = 0; $i -lt 50; ++$i) {
     $nexps = Get-Process -Name '*explorer*' | Where-Object { $_.MainWindowHandle -gt 0 }
     if ($nexps.length -gt $exps.length) {
@@ -64,9 +64,9 @@ if (($m -is [string]) -or (($m -is [array]) -and ($m.length -gt 0))) {
 Write-Host
 Write-Host "Starting Explorer #2"
 $dir = Resolve-Path $repoPath
-Write-Host "/SELECT,`"$dir\Version.h`""
+Write-Host "/SELECT, `"$dir\Version.h`""
 $exps = Get-Process -Name '*explorer*' | Where-Object { $_.MainWindowHandle -gt 0 }
-explorer.exe "/SELECT,`"$dir\Version.h`""
+explorer.exe "/SELECT," "$dir\Version.h"
 for ($i = 0; $i -lt 50; ++$i) {
     $nexps = Get-Process -Name '*explorer*' | Where-Object { $_.MainWindowHandle -gt 0 }
     if ($nexps.length -gt $exps.length) {

--- a/SettingsApp/FolderPicker.cs
+++ b/SettingsApp/FolderPicker.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Windows; // for WPF support
+using System.Windows.Interop;  // for WPF support
+
+namespace OpenHere.SettingsApp
+{
+
+    /// <summary>
+    /// Folder picking dialog
+    /// https://stackoverflow.com/a/66187224/552373
+    /// </summary>
+    internal class FolderPicker
+    {
+        public virtual string? ResultPath { get; protected set; }
+        public virtual string? ResultName { get; protected set; }
+        public virtual string? InputPath { get; set; }
+        public virtual bool ForceFileSystem { get; set; }
+        public virtual string? Title { get; set; }
+        public virtual string? OkButtonLabel { get; set; }
+        public virtual string? FileNameLabel { get; set; }
+
+        protected virtual int SetOptions(int options)
+        {
+            if (ForceFileSystem)
+            {
+                options |= (int)FOS.FOS_FORCEFILESYSTEM;
+            }
+            return options;
+        }
+
+        // for WPF support
+        public bool? ShowDialog(Window? owner = null, bool throwOnError = false)
+        {
+            owner ??= Application.Current.MainWindow;
+            return ShowDialog(owner != null ? new WindowInteropHelper(owner).Handle : IntPtr.Zero, throwOnError);
+        }
+
+        // for all .NET
+        public virtual bool? ShowDialog(IntPtr owner, bool throwOnError = false)
+        {
+            var dialog = (IFileOpenDialog)new FileOpenDialog();
+            if (!string.IsNullOrEmpty(InputPath))
+            {
+                if (CheckHr(SHCreateItemFromParsingName(InputPath, null, typeof(IShellItem).GUID, out var item), throwOnError) != 0)
+                    return null;
+
+                dialog.SetFolder(item);
+            }
+
+            var options = FOS.FOS_PICKFOLDERS;
+            options = (FOS)SetOptions((int)options);
+            dialog.SetOptions(options);
+
+            if (Title != null)
+            {
+                dialog.SetTitle(Title);
+            }
+
+            if (OkButtonLabel != null)
+            {
+                dialog.SetOkButtonLabel(OkButtonLabel);
+            }
+
+            if (FileNameLabel != null)
+            {
+                dialog.SetFileName(FileNameLabel);
+            }
+
+            if (owner == IntPtr.Zero)
+            {
+                owner = Process.GetCurrentProcess().MainWindowHandle;
+                if (owner == IntPtr.Zero)
+                {
+                    owner = GetDesktopWindow();
+                }
+            }
+
+            var hr = dialog.Show(owner);
+            if (hr == ERROR_CANCELLED)
+                return null;
+
+            if (CheckHr(hr, throwOnError) != 0)
+                return null;
+
+            if (CheckHr(dialog.GetResult(out var result), throwOnError) != 0)
+                return null;
+
+            if (CheckHr(result.GetDisplayName(SIGDN.SIGDN_DESKTOPABSOLUTEPARSING, out var path), throwOnError) != 0)
+                return null;
+
+            ResultPath = path;
+
+            if (CheckHr(result.GetDisplayName(SIGDN.SIGDN_DESKTOPABSOLUTEEDITING, out path), false) == 0)
+            {
+                ResultName = path;
+            }
+            return true;
+        }
+
+        private static int CheckHr(int hr, bool throwOnError)
+        {
+            if (hr != 0)
+            {
+                if (throwOnError)
+                    Marshal.ThrowExceptionForHR(hr);
+            }
+            return hr;
+        }
+
+        [DllImport("shell32")]
+        private static extern int SHCreateItemFromParsingName([MarshalAs(UnmanagedType.LPWStr)] string pszPath, IBindCtx? pbc, [MarshalAs(UnmanagedType.LPStruct)] Guid riid, out IShellItem ppv);
+
+        [DllImport("user32")]
+        private static extern IntPtr GetDesktopWindow();
+
+#pragma warning disable IDE1006 // Naming Styles
+        private const int ERROR_CANCELLED = unchecked((int)0x800704C7);
+#pragma warning restore IDE1006 // Naming Styles
+
+        [ComImport, Guid("DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7")] // CLSID_FileOpenDialog
+        private class FileOpenDialog
+        {
+        }
+
+        [ComImport, Guid("42f85136-db7e-439c-85f1-e4075d135fc8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IFileOpenDialog
+        {
+            [PreserveSig] int Show(IntPtr parent); // IModalWindow
+            [PreserveSig] int SetFileTypes();  // not fully defined
+            [PreserveSig] int SetFileTypeIndex(int iFileType);
+            [PreserveSig] int GetFileTypeIndex(out int piFileType);
+            [PreserveSig] int Advise(); // not fully defined
+            [PreserveSig] int Unadvise();
+            [PreserveSig] int SetOptions(FOS fos);
+            [PreserveSig] int GetOptions(out FOS pfos);
+            [PreserveSig] int SetDefaultFolder(IShellItem psi);
+            [PreserveSig] int SetFolder(IShellItem psi);
+            [PreserveSig] int GetFolder(out IShellItem ppsi);
+            [PreserveSig] int GetCurrentSelection(out IShellItem ppsi);
+            [PreserveSig] int SetFileName([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+            [PreserveSig] int GetFileName([MarshalAs(UnmanagedType.LPWStr)] out string pszName);
+            [PreserveSig] int SetTitle([MarshalAs(UnmanagedType.LPWStr)] string pszTitle);
+            [PreserveSig] int SetOkButtonLabel([MarshalAs(UnmanagedType.LPWStr)] string pszText);
+            [PreserveSig] int SetFileNameLabel([MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+            [PreserveSig] int GetResult(out IShellItem ppsi);
+            [PreserveSig] int AddPlace(IShellItem psi, int alignment);
+            [PreserveSig] int SetDefaultExtension([MarshalAs(UnmanagedType.LPWStr)] string pszDefaultExtension);
+            [PreserveSig] int Close(int hr);
+            [PreserveSig] int SetClientGuid();  // not fully defined
+            [PreserveSig] int ClearClientData();
+            [PreserveSig] int SetFilter([MarshalAs(UnmanagedType.IUnknown)] object pFilter);
+            [PreserveSig] int GetResults([MarshalAs(UnmanagedType.IUnknown)] out object ppenum);
+            [PreserveSig] int GetSelectedItems([MarshalAs(UnmanagedType.IUnknown)] out object ppsai);
+        }
+
+        [ComImport, Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IShellItem
+        {
+            [PreserveSig] int BindToHandler(); // not fully defined
+            [PreserveSig] int GetParent(); // not fully defined
+            [PreserveSig] int GetDisplayName(SIGDN sigdnName, [MarshalAs(UnmanagedType.LPWStr)] out string ppszName);
+            [PreserveSig] int GetAttributes();  // not fully defined
+            [PreserveSig] int Compare();  // not fully defined
+        }
+
+#pragma warning disable CA1712 // Do not prefix enum values with type name
+        private enum SIGDN : uint
+        {
+            SIGDN_DESKTOPABSOLUTEEDITING = 0x8004c000,
+            SIGDN_DESKTOPABSOLUTEPARSING = 0x80028000,
+            SIGDN_FILESYSPATH = 0x80058000,
+            SIGDN_NORMALDISPLAY = 0,
+            SIGDN_PARENTRELATIVE = 0x80080001,
+            SIGDN_PARENTRELATIVEEDITING = 0x80031001,
+            SIGDN_PARENTRELATIVEFORADDRESSBAR = 0x8007c001,
+            SIGDN_PARENTRELATIVEPARSING = 0x80018001,
+            SIGDN_URL = 0x80068000
+        }
+
+        [Flags]
+        private enum FOS
+        {
+            FOS_OVERWRITEPROMPT = 0x2,
+            FOS_STRICTFILETYPES = 0x4,
+            FOS_NOCHANGEDIR = 0x8,
+            FOS_PICKFOLDERS = 0x20,
+            FOS_FORCEFILESYSTEM = 0x40,
+            FOS_ALLNONSTORAGEITEMS = 0x80,
+            FOS_NOVALIDATE = 0x100,
+            FOS_ALLOWMULTISELECT = 0x200,
+            FOS_PATHMUSTEXIST = 0x800,
+            FOS_FILEMUSTEXIST = 0x1000,
+            FOS_CREATEPROMPT = 0x2000,
+            FOS_SHAREAWARE = 0x4000,
+            FOS_NOREADONLYRETURN = 0x8000,
+            FOS_NOTESTFILECREATE = 0x10000,
+            FOS_HIDEMRUPLACES = 0x20000,
+            FOS_HIDEPINNEDPLACES = 0x40000,
+            FOS_NODEREFERENCELINKS = 0x100000,
+            FOS_OKBUTTONNEEDSINTERACTION = 0x200000,
+            FOS_DONTADDTORECENT = 0x2000000,
+            FOS_FORCESHOWHIDDEN = 0x10000000,
+            FOS_DEFAULTNOMINIMODE = 0x20000000,
+            FOS_FORCEPREVIEWPANEON = 0x40000000,
+            FOS_SUPPORTSTREAMABLEITEMS = unchecked((int)0x80000000)
+        }
+#pragma warning restore CA1712 // Do not prefix enum values with type name
+
+    }
+}

--- a/SettingsApp/MainWindow.xaml.cs
+++ b/SettingsApp/MainWindow.xaml.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 //
 using Microsoft.Win32;
-using Microsoft.WindowsAPICodePack.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -192,15 +191,13 @@ namespace OpenHere.SettingsApp
 
         private void ButtonImport_Click(object sender, RoutedEventArgs e)
         {
-            CommonOpenFileDialog ofd = new CommonOpenFileDialog();
+            OpenFileDialog ofd = new();
             ofd.Title = "Open Here Import...";
             ofd.RestoreDirectory = false;
-            ofd.EnsureFileExists = true;
-            ofd.AllowNonFileSystemItems = false;
-            ofd.Filters.Add(new CommonFileDialogFilter("Xml Files", ".xml"));
-            ofd.Filters.Add(new CommonFileDialogFilter("All Files", "*.*"));
+            ofd.CheckFileExists = true;
+            ofd.Filter = "Xml Files|*.xml|All Files|*.*";
 
-            if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
+            if (ofd.ShowDialog(this) ?? false)
             {
                 try
                 {
@@ -232,14 +229,13 @@ namespace OpenHere.SettingsApp
 
         private void ButtonExport_Click(object sender, RoutedEventArgs e)
         {
-            CommonSaveFileDialog sfd = new CommonSaveFileDialog();
+            SaveFileDialog sfd = new();
             sfd.Title = "Open Here Export...";
             sfd.RestoreDirectory = false;
-            sfd.EnsurePathExists = true;
-            sfd.Filters.Add(new CommonFileDialogFilter("Xml Files", ".xml"));
-            sfd.Filters.Add(new CommonFileDialogFilter("All Files", "*.*"));
+            sfd.CheckPathExists = true;
+            sfd.Filter = "Xml Files|*.xml|All Files|*.*";
 
-            if (sfd.ShowDialog(this) == CommonFileDialogResult.Ok)
+            if (sfd.ShowDialog(this) ?? false)
             {
                 ImportExport ie = new ImportExport();
                 ie.Config = Config;
@@ -596,16 +592,16 @@ namespace OpenHere.SettingsApp
             SettingsBase.ToolStartConfig? sel = (lvi != null) ? StartConfigList.ItemContainerGenerator.ItemFromContainer(lvi) as SettingsBase.ToolStartConfig : null;
             if (tool == null || sel == null) return;
 
-            CommonOpenFileDialog ofd = new CommonOpenFileDialog();
+            OpenFileDialog ofd = new();
             ofd.Title = tool.Title + " Executable...";
-            ofd.DefaultFileName = sel.Executable;
+            ofd.FileName = sel.Executable;
             ofd.RestoreDirectory = false;
             if (!string.IsNullOrWhiteSpace(sel.Executable))
             {
                 ofd.InitialDirectory = System.IO.Path.GetDirectoryName(sel.Executable);
             }
 
-            if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
+            if (ofd.ShowDialog(this) ?? false)
             {
                 sel.Executable = ofd.FileName;
             }
@@ -618,19 +614,21 @@ namespace OpenHere.SettingsApp
             SettingsBase.ToolStartConfig? sel = (lvi != null) ? StartConfigList.ItemContainerGenerator.ItemFromContainer(lvi) as SettingsBase.ToolStartConfig : null;
             if (tool == null || sel == null) return;
 
-            CommonOpenFileDialog ofd = new CommonOpenFileDialog();
-            ofd.Title = tool.Title + " Working Directory...";
-            ofd.IsFolderPicker = true;
-            ofd.RestoreDirectory = false;
-            if (!string.IsNullOrWhiteSpace(sel.WorkingDirectory))
-            {
-                ofd.InitialDirectory = sel.WorkingDirectory;
-            }
+            // TODO: Implement using folder picker
+            //OpenFileDialog ofd = new();
+            //ofd.Title = tool.Title + " Working Directory...";
+            //ofd.
+            //ofd.IsFolderPicker = true;
+            //ofd.RestoreDirectory = false;
+            //if (!string.IsNullOrWhiteSpace(sel.WorkingDirectory))
+            //{
+            //    ofd.InitialDirectory = sel.WorkingDirectory;
+            //}
 
-            if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
-            {
-                sel.WorkingDirectory = ofd.FileName;
-            }
+            //if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
+            //{
+            //    sel.WorkingDirectory = ofd.FileName;
+            //}
 
         }
 
@@ -639,8 +637,8 @@ namespace OpenHere.SettingsApp
             ToolInfoView? tool = ToolsList.SelectedItem as ToolInfoView;
             if (tool == null) return;
 
-            CommonOpenFileDialog ofd = SelectIconDialog.CreateOpenFileDialog(tool.Title, tool.IconFile);
-            if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
+            OpenFileDialog ofd = SelectIconDialog.CreateOpenFileDialog(tool.Title, tool.IconFile);
+            if (ofd.ShowDialog(this) ?? false)
             {
                 try
                 {

--- a/SettingsApp/MainWindow.xaml.cs
+++ b/SettingsApp/MainWindow.xaml.cs
@@ -614,22 +614,17 @@ namespace OpenHere.SettingsApp
             SettingsBase.ToolStartConfig? sel = (lvi != null) ? StartConfigList.ItemContainerGenerator.ItemFromContainer(lvi) as SettingsBase.ToolStartConfig : null;
             if (tool == null || sel == null) return;
 
-            // TODO: Implement using folder picker
-            //OpenFileDialog ofd = new();
-            //ofd.Title = tool.Title + " Working Directory...";
-            //ofd.
-            //ofd.IsFolderPicker = true;
-            //ofd.RestoreDirectory = false;
-            //if (!string.IsNullOrWhiteSpace(sel.WorkingDirectory))
-            //{
-            //    ofd.InitialDirectory = sel.WorkingDirectory;
-            //}
-
-            //if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
-            //{
-            //    sel.WorkingDirectory = ofd.FileName;
-            //}
-
+            var dlg = new FolderPicker();
+            dlg.Title = tool.Title + " Working Directory...";
+            dlg.ForceFileSystem = true;
+            if (!string.IsNullOrWhiteSpace(sel.WorkingDirectory))
+            {
+                dlg.InputPath = sel.WorkingDirectory;
+            }
+            if (dlg.ShowDialog() == true)
+            {
+                sel.WorkingDirectory = dlg.ResultPath;
+            }
         }
 
         private void ButtonBrowseToolIcon_Click(object sender, RoutedEventArgs e)

--- a/SettingsApp/SelectIconDialog.xaml.cs
+++ b/SettingsApp/SelectIconDialog.xaml.cs
@@ -125,7 +125,7 @@ namespace OpenHere.SettingsApp
 
         private void ButtonBrowse_Click(object sender, RoutedEventArgs e)
         {
-			OpenFileDialog ofd = CreateOpenFileDialog("", Filename);
+            OpenFileDialog ofd = CreateOpenFileDialog("", Filename);
             ofd.Title = Title;
             if (ofd.ShowDialog(this) ?? false)
             {

--- a/SettingsApp/SelectIconDialog.xaml.cs
+++ b/SettingsApp/SelectIconDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.WindowsAPICodePack.Dialogs;
+﻿using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -100,24 +100,18 @@ namespace OpenHere.SettingsApp
             return toolTitle + " Select Icon...";
         }
 
-        public static CommonOpenFileDialog CreateOpenFileDialog(string toolTitle, string filename)
+        public static OpenFileDialog CreateOpenFileDialog(string toolTitle, string filename)
         {
-            CommonOpenFileDialog ofd = new CommonOpenFileDialog();
+            OpenFileDialog ofd = new();
             ofd.Title = DialogTitle(toolTitle);
-            ofd.DefaultFileName = filename;
+            ofd.FileName = filename;
             if (!string.IsNullOrWhiteSpace(filename))
             {
                 ofd.InitialDirectory = System.IO.Path.GetDirectoryName(filename);
             }
             ofd.RestoreDirectory = true;
-            ofd.EnsureFileExists = true;
-            ofd.AllowNonFileSystemItems = false;
-            ofd.Filters.Add(new CommonFileDialogFilter("Supported Files", ".ico;.exe;.dll"));
-            ofd.Filters.Add(new CommonFileDialogFilter("Icon Files", ".ico"));
-            ofd.Filters.Add(new CommonFileDialogFilter("Executables Files", ".exe"));
-            ofd.Filters.Add(new CommonFileDialogFilter("Dynamic Library Files", ".dll"));
-            ofd.Filters.Add(new CommonFileDialogFilter("All Files", "*.*"));
-
+            ofd.CheckFileExists = true;
+            ofd.Filter = "Supported Files|*.ico;*.exe;*.dll|Icon Files|*.ico|Executables Files|*.exe|Dynamic Library Files|*.dll|All Files|*.*";
             return ofd;
         }
 
@@ -131,9 +125,9 @@ namespace OpenHere.SettingsApp
 
         private void ButtonBrowse_Click(object sender, RoutedEventArgs e)
         {
-            CommonOpenFileDialog ofd = CreateOpenFileDialog("", Filename);
+			OpenFileDialog ofd = CreateOpenFileDialog("", Filename);
             ofd.Title = Title;
-            if (ofd.ShowDialog(this) == CommonFileDialogResult.Ok)
+            if (ofd.ShowDialog(this) ?? false)
             {
                 Filename = ofd.FileName;
             }

--- a/SettingsApp/SettingsApp.csproj
+++ b/SettingsApp/SettingsApp.csproj
@@ -32,10 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\SettingsBaseLib\SettingsBaseLib.vcxproj" />
   </ItemGroup>
 

--- a/ToolboxLib/ToolboxLib.vcxproj
+++ b/ToolboxLib/ToolboxLib.vcxproj
@@ -189,12 +189,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets" Condition="Exists('..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets')" />
+    <Import Project="..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets" Condition="Exists('..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nlohmann.json.3.10.5\build\native\nlohmann.json.targets'))" />
+    <Error Condition="!Exists('..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\nlohmann.json.3.11.2\build\native\nlohmann.json.targets'))" />
   </Target>
 </Project>

--- a/ToolboxLib/packages.config
+++ b/ToolboxLib/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nlohmann.json" version="3.10.5" targetFramework="native" />
+  <package id="nlohmann.json" version="3.11.2" targetFramework="native" />
 </packages>

--- a/Version.h
+++ b/Version.h
@@ -1,5 +1,5 @@
 // Open Here
-// Copyright 2022 SGrottel (https://www.sgrottel.de)
+// Copyright 2022-2024 SGrottel (https://www.sgrottel.de)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 #define OPEN_HERE_VER_MAJOR	1
 #define OPEN_HERE_VER_MINOR	1
-#define OPEN_HERE_VER_PATCH	0
+#define OPEN_HERE_VER_PATCH	1
 #define OPEN_HERE_VER_BUILD	0
 
-#define OPEN_HERE_VER_YEARSTR	"2022-2023"
+#define OPEN_HERE_VER_YEARSTR	"2022-2024"


### PR DESCRIPTION
Mircosoft Windows APICodePack (Shell) Nuget is strangely orphaned.  This PR replaces it with WPF-system native classes and a thin COM wrapper for the folder picker (first used in the checkouts-overview project)